### PR TITLE
chore(dependencies):  use bonita-engine 7.9.2

### DIFF
--- a/embedded-engine-example/pom.xml
+++ b/embedded-engine-example/pom.xml
@@ -8,7 +8,7 @@
     <version>1.2.0-SNAPSHOT</version>
 
     <properties>
-        <bonita.engine.version>7.9.0-SNAPSHOT</bonita.engine.version>
+        <bonita.engine.version>7.9.2</bonita.engine.version>
         <h2.version>1.3.170</h2.version>
     </properties>
 


### PR DESCRIPTION
Previous configuration depends on bonita-engine 7.9.0-SNAPSHOT which is not publicly available so building
bonita-engine was required prior being able to run the example.